### PR TITLE
Implemented ~~~~ replacement by SignatureMacro, and showing username and timestamp

### DIFF
--- a/tracplugins/mediawikisignature.py
+++ b/tracplugins/mediawikisignature.py
@@ -8,11 +8,13 @@
 
 from datetime import datetime
 
-from trac.core import Component, implements
+from trac.core import Component, implements, TracError
 from trac.util import get_reporter_id
-from trac.util.datefmt import format_datetime, localtz, user_time
+from trac.util.datefmt import format_datetime, localtz, user_time, parse_date
 from trac.wiki.api import IWikiPageManipulator, IWikiSyntaxProvider
 from trac.util.html import tag
+from trac.wiki.formatter import format_to_oneliner
+from trac.wiki.macros import WikiMacroBase
 
 class MediaWikiSignatureManipulator(Component):
     _description = "Replaces the MediaWiki signature with the author name."
@@ -34,18 +36,15 @@ class MediaWikiSignatureManipulator(Component):
 
             fullname = req.session.get('name')
             username = get_reporter_id(req)
-            signature = ''.join(['[[user:', username, '|', fullname or username, ']]'])
 
             tzinfo = getattr(req, 'tz', None)
             now = datetime.now(tzinfo or localtz)
             today = format_datetime(now, 'iso8601', tzinfo)
-            today_user = user_time(req, format_datetime, now, tzinfo=tzinfo)
-            timestamp = ''.join(['[[timeline:', today, '|', today_user, ']]'])
 
             # Replace the tilde signature starting with the longest
-            replacetext = replacetext.replace('~~~~~', '-- ' + timestamp)
-            replacetext = replacetext.replace('~~~~', '-- ' + signature + ' ' + timestamp)
-            replacetext = replacetext.replace('~~~', '-- ' + signature)
+            replacetext = replacetext.replace('~~~~~', ''.join(['-- [[Signature(,', today, ')]]']))
+            replacetext = replacetext.replace('~~~~', ''.join(['-- [[Signature(', username, ', ', today, ', ', fullname or '', ')]]']))
+            replacetext = replacetext.replace('~~~', ''.join(['-- [[Signature(', username, ', , ', fullname or '', ')]]']))
 
             page.text = prefix + replacetext
 
@@ -59,6 +58,62 @@ class MediaWikiSignatureManipulator(Component):
     def get_link_resolvers(self):
         def link_resolver(formatter, ns, target, label):
             username = target
-            return tag.a(label, title='Link to user: ' + username, href='https://www.google.com')
+            return tag.a(label, title='Link to user: ' + username, href='https://www.google.com', class_='trac-author-user')
 
         yield 'user', link_resolver
+
+class SignatureMacro(WikiMacroBase):
+    _description = (
+    """Expands the passed username, date and full-username to a MediaWiki like signature""")
+
+    def expand_macro(self, formatter, name, content, args):
+        if content:
+            args = content.split(',')
+
+            username = None
+            timestamp = None
+            fullusername = None
+            if len(args) > 0:
+                username = args[0]
+                if not username:
+                    username = username.strip()
+            if len(args) > 1:
+                timestamp = args[1]
+                if not timestamp:
+                    timestamp = timestamp.strip()
+            if len(args) > 2:
+                # Need to handle the situation that a , is present in the fullname
+                fullusername = args[2]
+                if not fullusername:
+                    fullusername = fullusername.strip()
+
+            if not username or len(username) == 0:
+                username = None
+            if not timestamp or len(timestamp) == 0:
+                timestamp = None
+            if not fullusername or len(fullusername) == 0:
+                fullusername = None
+
+            if not fullusername:
+                fullusername = username
+
+            signature = fullusername
+            if username:
+                signature = ''.join(['[[user:', username, '|', fullusername or username, ']]'])
+
+            timeline = ''
+            if timestamp:
+                tzinfo = getattr(formatter.context.req, 'tz', None)
+                try:
+                    dateobject = parse_date(timestamp)
+                    today_user = user_time(formatter.context.req, format_datetime, dateobject, tzinfo=tzinfo)
+                    timeline = ''.join(['[[timeline:', timestamp, '|', today_user, ']]'])
+                except TracError:
+                    pass
+
+            result = ''.join([signature or '', ' ', timeline or '']).strip()
+            # Convert Wiki markup to HTML
+            return format_to_oneliner(self.env, formatter.context, result)
+        else:
+            # No content is parsed
+            return ''

--- a/tracplugins/mediawikisignature.py
+++ b/tracplugins/mediawikisignature.py
@@ -6,14 +6,18 @@
 # This software is licensed as described in the file LICENSE, which
 # you should have received as part of this distribution.
 
+from datetime import datetime
+
 from trac.core import Component, implements
 from trac.util import get_reporter_id
-from trac.wiki.api import IWikiPageManipulator
+from trac.util.datefmt import format_datetime, localtz, user_time
+from trac.wiki.api import IWikiPageManipulator, IWikiSyntaxProvider
+from trac.util.html import tag
 
 class MediaWikiSignatureManipulator(Component):
     _description = "Replaces the MediaWiki signature with the author name."
 
-    implements(IWikiPageManipulator)
+    implements(IWikiPageManipulator, IWikiSyntaxProvider)
 
     # IWikiPageManipulator
 
@@ -21,14 +25,40 @@ class MediaWikiSignatureManipulator(Component):
         pass
 
     def validate_wiki_page(self, req, page):
-        text = page.text
-        if len(text):
-            fullname = req.session.get('name') or ''
-            username = get_reporter_id(req)
-            signature = username
-            if len(fullname):
-                signature = fullname + ' (%s)' % username
+        startpos = page.text.find('~~~')
+        if startpos >= 0:
+            # Only search and replace in the part that we found
+            # a 3-tilde signature
+            prefix = page.text[:startpos]
+            replacetext = page.text[startpos:]
 
-            page.text = text.replace('~~~~', signature)
+            fullname = req.session.get('name')
+            username = get_reporter_id(req)
+            signature = ''.join(['[[user:', username, '|', fullname or username, ']]'])
+
+            tzinfo = getattr(req, 'tz', None)
+            now = datetime.now(tzinfo or localtz)
+            today = format_datetime(now, 'iso8601', tzinfo)
+            today_user = user_time(req, format_datetime, now, tzinfo=tzinfo)
+            timestamp = ''.join(['[[timeline:', today, '|', today_user, ']]'])
+
+            # Replace the tilde signature starting with the longest
+            replacetext = replacetext.replace('~~~~~', '-- ' + timestamp)
+            replacetext = replacetext.replace('~~~~', '-- ' + signature + ' ' + timestamp)
+            replacetext = replacetext.replace('~~~', '-- ' + signature)
+
+            page.text = prefix + replacetext
 
         return []
+
+    # IWikiSyntaxProvider methods
+
+    def get_wiki_syntax(self):
+        return []
+
+    def get_link_resolvers(self):
+        def link_resolver(formatter, ns, target, label):
+            username = target
+            return tag.a(label, title='Link to user: ' + username, href='https://www.google.com')
+
+        yield 'user', link_resolver

--- a/tracplugins/mediawikisignature.py
+++ b/tracplugins/mediawikisignature.py
@@ -6,3 +6,29 @@
 # This software is licensed as described in the file LICENSE, which
 # you should have received as part of this distribution.
 
+from trac.core import Component, implements
+from trac.util import get_reporter_id
+from trac.wiki.api import IWikiPageManipulator
+
+class MediaWikiSignatureManipulator(Component):
+    _description = "Replaces the MediaWiki signature with the author name."
+
+    implements(IWikiPageManipulator)
+
+    # IWikiPageManipulator
+
+    def prepare_wiki_page(self, req, page, fields):
+        pass
+
+    def validate_wiki_page(self, req, page):
+        text = page.text
+        if len(text):
+            fullname = req.session.get('name') or ''
+            username = get_reporter_id(req)
+            signature = username
+            if len(fullname):
+                signature = fullname + ' (%s)' % username
+
+            page.text = text.replace('~~~~', signature)
+
+        return []


### PR DESCRIPTION
The replacement of the ~~~, ~~~~ and ~~~~~ is executed when a wiki page is saved. Those identifiers will be replaced by a [[Signature(.....)]] macro. The [[Signature(....)]] macro then formats the username and timestamp in the expected way to the wiki page viewer.

* Fixes: #6: ~ signature can better be converted to a Signature macro
* Fixes: #10: The username should be shown with the 'trac-author-user' CSS class
