### PR TITLE
Fixes that a date in the future is marked as being '... ago'

### DIFF
--- a/tracplugins/mediawikisignature.py
+++ b/tracplugins/mediawikisignature.py
@@ -123,7 +123,10 @@ class SignatureMacro(WikiMacroBase):
                 try:
                     dateobject = parse_date(timestamp)
                     now = datetime.now(tzinfo or localtz)
-                    pretty_diff = pretty_timedelta(dateobject, now) + ' ago'
+                    date_suffix = ' ago'
+                    if dateobject > now:
+                        date_suffix = ' in the future'
+                    pretty_diff = pretty_timedelta(dateobject, now) + date_suffix
                     timeline = ''.join(['[[timeline:', timestamp, '|', pretty_diff, ']]'])
                 except TracError:
                     pass


### PR DESCRIPTION
* Fixes: #32: If a timestamp in the future is passed, it still states it as 'ago'
* A future timestamp will now be shown as: '.... in the future'